### PR TITLE
Add force flag

### DIFF
--- a/cmd/convert.go
+++ b/cmd/convert.go
@@ -49,6 +49,7 @@ type convertCmd struct {
 	stringValues []string
 	version      string
 	depUp        bool
+	forceGen     bool
 
 	username string
 	password string
@@ -127,6 +128,7 @@ func NewConvertCommand() *cobra.Command {
 	f.StringVar(&k.keyFile, "key-file", "", "identify HTTPS client using this SSL key file")
 	f.StringVar(&k.caFile, "ca-file", "", "verify certificates of HTTPS-enabled servers using this CA bundle")
 	f.BoolVar(&k.depUp, "dep-up", false, "run helm dependency update before installing the chart")
+	f.BoolVar(&k.forceGen, "force", false, "convert chart even if the destination directory already exists")
 	f.StringVar(&k.username, "username", "", "chart repository username")
 	f.StringVar(&k.password, "password", "", "chart repository password")
 
@@ -232,7 +234,7 @@ func (k *convertCmd) run() error {
 	}
 
 	// write to disk
-	generator := generators.NewGenerator()
+	generator := generators.NewGenerator(k.forceGen)
 	err = generator.Render(k.destination, config, chartRequested.Metadata, resources)
 	if err != nil {
 		return err

--- a/go.sum
+++ b/go.sum
@@ -95,7 +95,7 @@ k8s.io/api v0.0.0-20180628040859-072894a440bd h1:HzgYeLDS1jLxw8DGr68KJh9cdQ5iZJi
 k8s.io/api v0.0.0-20180628040859-072894a440bd/go.mod h1:iuAfoD4hCxJ8Onx9kaTIt30j7jUFS00AXQi6QMi99vA=
 k8s.io/apimachinery v0.0.0-20180621070125-103fd098999d h1:MZjlsu9igBoVPZkXpIGoxI6EonqNsXXZU7hhvfQLkd4=
 k8s.io/apimachinery v0.0.0-20180621070125-103fd098999d/go.mod h1:ccL7Eh7zubPUSh9A3USN90/OzHNSVN6zxzde07TDCL0=
-k8s.io/client-go v7.0.0+incompatible h1:gokIETH5yPpln/LuXmg1TLVH5bMSaVQTVxuRizwjWwU=
+k8s.io/client-go v7.0.0+incompatible h1:kiH+Y6hn+pc78QS/mtBfMJAMIIaWevHi++JvOGEEQp4=
 k8s.io/client-go v7.0.0+incompatible/go.mod h1:7vJpHMYJwNQCWgzmNV+VYUl1zCObLyodBc8nIyt8L5s=
 k8s.io/helm v2.11.0-rc.4+incompatible h1:+eF/aGKA9M2u2TVFyWFyMIA7lChdMdvyBFuXzZsoXRo=
 k8s.io/helm v2.11.0-rc.4+incompatible/go.mod h1:LZzlS4LQBHfciFOurYBFkCMTaZ0D1l+p0teMg7TSULI=

--- a/go.sum
+++ b/go.sum
@@ -95,7 +95,7 @@ k8s.io/api v0.0.0-20180628040859-072894a440bd h1:HzgYeLDS1jLxw8DGr68KJh9cdQ5iZJi
 k8s.io/api v0.0.0-20180628040859-072894a440bd/go.mod h1:iuAfoD4hCxJ8Onx9kaTIt30j7jUFS00AXQi6QMi99vA=
 k8s.io/apimachinery v0.0.0-20180621070125-103fd098999d h1:MZjlsu9igBoVPZkXpIGoxI6EonqNsXXZU7hhvfQLkd4=
 k8s.io/apimachinery v0.0.0-20180621070125-103fd098999d/go.mod h1:ccL7Eh7zubPUSh9A3USN90/OzHNSVN6zxzde07TDCL0=
-k8s.io/client-go v7.0.0+incompatible h1:kiH+Y6hn+pc78QS/mtBfMJAMIIaWevHi++JvOGEEQp4=
+k8s.io/client-go v7.0.0+incompatible h1:gokIETH5yPpln/LuXmg1TLVH5bMSaVQTVxuRizwjWwU=
 k8s.io/client-go v7.0.0+incompatible/go.mod h1:7vJpHMYJwNQCWgzmNV+VYUl1zCObLyodBc8nIyt8L5s=
 k8s.io/helm v2.11.0-rc.4+incompatible h1:+eF/aGKA9M2u2TVFyWFyMIA7lChdMdvyBFuXzZsoXRo=
 k8s.io/helm v2.11.0-rc.4+incompatible/go.mod h1:LZzlS4LQBHfciFOurYBFkCMTaZ0D1l+p0teMg7TSULI=

--- a/pkg/generators/generators.go
+++ b/pkg/generators/generators.go
@@ -29,11 +29,13 @@ const (
 )
 
 // Generator type
-type Generator struct{}
+type Generator struct {
+	force bool
+}
 
 // NewGenerator contructs a new generator
-func NewGenerator() *Generator {
-	return &Generator{}
+func NewGenerator(force bool) *Generator {
+	return &Generator{force}
 }
 
 // Render to disk the kustomization.yaml, Kube-descriptor.yaml and associated resources
@@ -42,13 +44,15 @@ func (g *Generator) Render(destination string, config *types.Kustomization, meta
 
 	// chech if destination path already exist, prompt user to confirm override
 	if ok, _ := utils.PathExists(destination); ok {
-		reader := bufio.NewReader(os.Stdin)
-		fmt.Printf("Destination directory '%s' already exist, override? [y/n]", destination)
-		approve, _ := reader.ReadString('\n')
-		approve = strings.Trim(approve, " \n")
+		if !g.force {
+			reader := bufio.NewReader(os.Stdin)
+			fmt.Printf("Destination directory '%s' already exist, override? [y/n] ", destination)
+			approve, _ := reader.ReadString('\n')
+			approve = strings.Trim(approve, " \n")
 
-		if approve != "y" && approve != "yes" {
-			return nil
+			if approve != "y" && approve != "yes" {
+				return nil
+			}
 		}
 	} else {
 		os.MkdirAll(destination, os.ModePerm)


### PR DESCRIPTION
ability to turn off the prompt warning you that the output directory already exists. I'm trying out helm-convert but calling it in a script b/c I currently need to do some post-processing of the files that are generated.

Thanks for making this. I've been working with kustomize and was thinking about building something similar when I ran across this.