### PR TITLE
Fix multi resource templates

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -42,7 +42,7 @@ require (
 	gopkg.in/yaml.v1 v1.0.0-20140924161607-9f9df34309c0 // indirect
 	gopkg.in/yaml.v2 v2.2.1 // indirect
 	k8s.io/api v0.0.0-20180628040859-072894a440bd
-	k8s.io/apimachinery v0.0.0-20180621070125-103fd098999d // indirect
+	k8s.io/apimachinery v0.0.0-20180621070125-103fd098999d
 	k8s.io/client-go v7.0.0+incompatible // indirect
 	k8s.io/helm v2.11.0-rc.4+incompatible
 	sigs.k8s.io/kustomize v1.0.9-0.20180927233047-30597252c70c

--- a/go.sum
+++ b/go.sum
@@ -95,7 +95,7 @@ k8s.io/api v0.0.0-20180628040859-072894a440bd h1:HzgYeLDS1jLxw8DGr68KJh9cdQ5iZJi
 k8s.io/api v0.0.0-20180628040859-072894a440bd/go.mod h1:iuAfoD4hCxJ8Onx9kaTIt30j7jUFS00AXQi6QMi99vA=
 k8s.io/apimachinery v0.0.0-20180621070125-103fd098999d h1:MZjlsu9igBoVPZkXpIGoxI6EonqNsXXZU7hhvfQLkd4=
 k8s.io/apimachinery v0.0.0-20180621070125-103fd098999d/go.mod h1:ccL7Eh7zubPUSh9A3USN90/OzHNSVN6zxzde07TDCL0=
-k8s.io/client-go v7.0.0+incompatible h1:gokIETH5yPpln/LuXmg1TLVH5bMSaVQTVxuRizwjWwU=
+k8s.io/client-go v7.0.0+incompatible h1:kiH+Y6hn+pc78QS/mtBfMJAMIIaWevHi++JvOGEEQp4=
 k8s.io/client-go v7.0.0+incompatible/go.mod h1:7vJpHMYJwNQCWgzmNV+VYUl1zCObLyodBc8nIyt8L5s=
 k8s.io/helm v2.11.0-rc.4+incompatible h1:+eF/aGKA9M2u2TVFyWFyMIA7lChdMdvyBFuXzZsoXRo=
 k8s.io/helm v2.11.0-rc.4+incompatible/go.mod h1:LZzlS4LQBHfciFOurYBFkCMTaZ0D1l+p0teMg7TSULI=

--- a/go.sum
+++ b/go.sum
@@ -95,7 +95,7 @@ k8s.io/api v0.0.0-20180628040859-072894a440bd h1:HzgYeLDS1jLxw8DGr68KJh9cdQ5iZJi
 k8s.io/api v0.0.0-20180628040859-072894a440bd/go.mod h1:iuAfoD4hCxJ8Onx9kaTIt30j7jUFS00AXQi6QMi99vA=
 k8s.io/apimachinery v0.0.0-20180621070125-103fd098999d h1:MZjlsu9igBoVPZkXpIGoxI6EonqNsXXZU7hhvfQLkd4=
 k8s.io/apimachinery v0.0.0-20180621070125-103fd098999d/go.mod h1:ccL7Eh7zubPUSh9A3USN90/OzHNSVN6zxzde07TDCL0=
-k8s.io/client-go v7.0.0+incompatible h1:kiH+Y6hn+pc78QS/mtBfMJAMIIaWevHi++JvOGEEQp4=
+k8s.io/client-go v7.0.0+incompatible h1:gokIETH5yPpln/LuXmg1TLVH5bMSaVQTVxuRizwjWwU=
 k8s.io/client-go v7.0.0+incompatible/go.mod h1:7vJpHMYJwNQCWgzmNV+VYUl1zCObLyodBc8nIyt8L5s=
 k8s.io/helm v2.11.0-rc.4+incompatible h1:+eF/aGKA9M2u2TVFyWFyMIA7lChdMdvyBFuXzZsoXRo=
 k8s.io/helm v2.11.0-rc.4+incompatible/go.mod h1:LZzlS4LQBHfciFOurYBFkCMTaZ0D1l+p0teMg7TSULI=


### PR DESCRIPTION
fixes #4 

Here is an attempt to fix this. Unfortunately, I couldn't find any exported functions in kustomize that I could use so I just borrowed some code.

With this change:

```
$ ./helm-convert --name cm stable/cert-manager -d out
$ grep ClusterRole out/*                                                                         
out/cm-cert-manager-clusterrole.yaml:kind: ClusterRole                                                                                                                                            
out/cm-cert-manager-crb.yaml:kind: ClusterRoleBinding                                                                                                                                             
out/cm-cert-manager-crb.yaml:  kind: ClusterRole
```