### PR TITLE
sort imagetags in kustomization output

### DIFF
--- a/pkg/transformers/imagetag.go
+++ b/pkg/transformers/imagetag.go
@@ -1,6 +1,7 @@
 package transformers
 
 import (
+	"sort"
 	"strings"
 
 	"github.com/ContainerSolutions/helm-convert/pkg/types"
@@ -28,6 +29,11 @@ func (pt *imageTagTransformer) Transform(config *ktypes.Kustomization, resources
 			continue
 		}
 	}
+
+	sort.Slice(config.ImageTags, func(i, j int) bool {
+		return imageTagString(config.ImageTags[i]) < imageTagString(config.ImageTags[j])
+	})
+
 	return nil
 }
 
@@ -117,4 +123,11 @@ func (pt *imageTagTransformer) findContainers(config *ktypes.Kustomization, obj 
 		}
 	}
 	return nil
+}
+
+func imageTagString(imageTag ktypes.ImageTag) string {
+	if imageTag.Digest != "" {
+		return imageTag.Name + "@" + imageTag.Digest
+	}
+	return imageTag.Name + ":" + imageTag.NewTag
 }

--- a/pkg/transformers/imagetag_test.go
+++ b/pkg/transformers/imagetag_test.go
@@ -90,9 +90,9 @@ func TestImageTagRun(t *testing.T) {
 			expected: &imageTagTransformerArgs{
 				config: &ktypes.Kustomization{
 					ImageTags: []ktypes.ImageTag{
-						ktypes.ImageTag{Name: "nginx", NewTag: "1.7.9"},
 						ktypes.ImageTag{Name: "alpine", Digest: "sha256:24a0c4b4a4c0eb97a1aabb8e29f18e917d05abfe1b7a7c07857230879ce7d3d3"},
 						ktypes.ImageTag{Name: "busybox"},
+						ktypes.ImageTag{Name: "nginx", NewTag: "1.7.9"},
 					},
 				},
 				resources: &types.Resources{


### PR DESCRIPTION
so that you get the same kustomization.yaml every time you run helm-convert on the same chart